### PR TITLE
Add Python 3.8 and 3.9 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,14 @@ matrix:
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7
-      dist: xenial
       env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
+    - python: 3.9
+      env: TOXENV=py39
     - python: pypy
       env: TOXENV=pypy
     - python: pypy3
       env: TOXENV=pypy3
     - python: 3.7
-      dist: xenial
       env: TOXENV=lint

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Features
 - SegmentList - List with fast random access insertion and deletion.
 - 100% code coverage testing.
 - Developed on Python 3.7
-- Tested on CPython 2.7, 3.4, 3.5, 3.6, 3.7 and PyPy, PyPy3
+- Tested on CPython 2.7, 3.4, 3.5, 3.6, 3.7, 3.8, 3.9, and PyPy, PyPy3
 
 .. image:: https://api.travis-ci.org/grantjenks/python-sortedcollections.svg?branch=master
     :target: http://www.grantjenks.com/docs/sortedcollections/

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,6 +10,8 @@ environment:
     - PYTHON: "C:\\Python35-x64"
     - PYTHON: "C:\\Python36-x64"
     - PYTHON: "C:\\Python37-x64"
+    - PYTHON: "C:\\Python38-x64"
+    - PYTHON: "C:\\Python39-x64"
 
 install:
 

--- a/setup.py
+++ b/setup.py
@@ -44,6 +44,8 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ),

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py34,py35,py36,py37,pypy,pypy3,lint
+envlist=py27,py34,py35,py36,py37,py38,py39,pypy,pypy3,lint
 skip_missing_interpreters=True
 
 [testenv]


### PR DESCRIPTION
Add Python 3.8 and 3.9 to all CIs and docs.

@grantjenks would you consider dropping support for all old Python versions after their EOL (2.7, 3.2, 3.3, 3.4, 3.5)?