### PR TITLE
Modernize code to Python 3.6+

### DIFF
--- a/sortedcollections/nearestdict.py
+++ b/sortedcollections/nearestdict.py
@@ -52,7 +52,7 @@ class NearestDict(SortedDict):
         :params kwargs: keyword arguments for :class:`SortedDict`.
         """
         self.rounding = kwargs.pop('rounding', self.NEAREST)
-        super(NearestDict, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def nearest_key(self, request):
         """Return nearest-key to `request`, respecting `self.rounding`.
@@ -120,4 +120,4 @@ class NearestDict(SortedDict):
         KeyError: 'No key above 2.0 found'
         """
         key = self.nearest_key(request)
-        return super(NearestDict, self).__getitem__(key)
+        return super().__getitem__(key)

--- a/sortedcollections/nearestdict.py
+++ b/sortedcollections/nearestdict.py
@@ -84,12 +84,12 @@ class NearestDict(SortedDict):
 
         if index >= len(key_list):
             if self.rounding == self.NEAREST_NEXT:
-                raise KeyError('No key above {} found'.format(repr(request)))
+                raise KeyError(f'No key above {request!r} found')
             return key_list[index - 1]
         if key_list[index] == request:
             return key_list[index]
         if index == 0 and self.rounding == self.NEAREST_PREV:
-            raise KeyError('No key below {} found'.format(repr(request)))
+            raise KeyError(f'No key below {request!r} found')
         if self.rounding == self.NEAREST_PREV:
             return key_list[index - 1]
         if self.rounding == self.NEAREST_NEXT:

--- a/sortedcollections/ordereddict.py
+++ b/sortedcollections/ordereddict.py
@@ -166,7 +166,7 @@ class OrderedDict(dict):
     @recursive_repr()
     def __repr__(self):
         "Text representation of mapping."
-        return '%s(%r)' % (self.__class__.__name__, list(self.items()))
+        return f'{self.__class__.__name__}({list(self.items())!r})'
 
     __str__ = __repr__
 

--- a/sortedcollections/recipes.py
+++ b/sortedcollections/recipes.py
@@ -25,7 +25,7 @@ class IndexableDict(SortedDict):
     """
 
     def __init__(self, *args, **kwargs):
-        super(IndexableDict, self).__init__(hash, *args, **kwargs)
+        super().__init__(hash, *args, **kwargs)
 
 
 class IndexableSet(SortedSet):
@@ -43,7 +43,7 @@ class IndexableSet(SortedSet):
 
     # pylint: disable=too-many-ancestors
     def __init__(self, *args, **kwargs):
-        super(IndexableSet, self).__init__(*args, key=hash, **kwargs)
+        super().__init__(*args, key=hash, **kwargs)
 
     def __reduce__(self):
         return self.__class__, (set(self),)
@@ -76,7 +76,7 @@ class ItemSortedDict(SortedDict):
             return func(key, self[key])
 
         args[0] = key_func
-        super(ItemSortedDict, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def __delitem__(self, key):
         "``del mapping[key]``"
@@ -153,7 +153,7 @@ class ValueSortedDict(SortedDict):
                 args[0] = key_func
             else:
                 args.insert(0, key_func)
-        super(ValueSortedDict, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def __delitem__(self, key):
         "``del mapping[key]``"
@@ -281,7 +281,7 @@ class SegmentList(SortedKeyList):
 
     # pylint: disable=too-many-ancestors
     def __init__(self, iterable=()):
-        super(SegmentList, self).__init__(iterable, self.zero)
+        super().__init__(iterable, self.zero)
 
     @staticmethod
     def zero(_):

--- a/sortedcollections/recipes.py
+++ b/sortedcollections/recipes.py
@@ -185,11 +185,8 @@ class ValueSortedDict(SortedDict):
 
     @recursive_repr()
     def __repr__(self):
-        temp = '{0}({1}, {{{2}}})'
-        items = ', '.join(
-            '{0}: {1}'.format(repr(key), repr(self[key])) for key in self._list
-        )
-        return temp.format(self.__class__.__name__, repr(self._func), items)
+        items = ', '.join(f'{key!r}: {self[key]!r}' for key in self._list)
+        return f'{self.__class__.__name__}({self._func!r}, {{{items}}})'
 
 
 class OrderedSet(abc.MutableSet, abc.Sequence):
@@ -248,7 +245,7 @@ class OrderedSet(abc.MutableSet, abc.Sequence):
         try:
             return self._keys[value]
         except KeyError:
-            raise ValueError('%r is not in %s' % (value, type(self).__name__))
+            raise ValueError(f'{value!r} is not in {type(self).__name__}')
 
     def add(self, value):
         "Add element, value, to set."
@@ -265,7 +262,7 @@ class OrderedSet(abc.MutableSet, abc.Sequence):
 
     def __repr__(self):
         "Text representation of set."
-        return '%s(%r)' % (type(self).__name__, list(self))
+        return f'{type(self).__name__}({list(self)!r})'
 
     __str__ = __repr__
 

--- a/tests/test_valuesorteddict.py
+++ b/tests/test_valuesorteddict.py
@@ -78,7 +78,7 @@ def test_pickle():
     assert original == duplicate
 
 
-class Negater(object):
+class Negater:
     def __call__(self, value):
         return -value
 


### PR DESCRIPTION
Happy to see the project is at Python 3.6+

Now it can use Python3 defaults for `super()` and the class syntax (without `(object)`)

And f-strings instead of `%` formatting or `.format`.